### PR TITLE
[Bug] iOS9 crash when setting automaticallyWaitsToMinimzeStalling

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -219,7 +219,9 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     
     // Callback when ready / failed
     if (player.currentItem.status == AVPlayerStatusReadyToPlay) {
-        player.automaticallyWaitsToMinimizeStalling = false;
+        if (version >= 10.0) {
+            player.automaticallyWaitsToMinimizeStalling = false;
+        }
         callback(@[[NSNull null]]);
     } else {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"


### PR DESCRIPTION
### Where

* Related PRs: https://github.com/lingokids/app/pull/5302

### What

`react-native-audio-toolkit` is  setting an AVPlayer property called `automaticallyWaitsToMinimizeStalling` (https://developer.apple.com/documentation/avfoundation/avplayer/1643482-automaticallywaitstominimizestal) on all iOS versions. This property is only available from iOS 10 onwards, hence its causing a crash on iOS9.

### How

I just added a a version check to the following line:

![Screenshot 2020-06-02 at 10 44 29](https://user-images.githubusercontent.com/1830021/83501272-2fbfda80-a4c0-11ea-9c2a-706489a11c1e.png)

As you can see this check is being done properly on other places, but for some reason the developer forgot to add it here.
